### PR TITLE
Add Display to a few Order Types; Add new TimeInForce variants 

### DIFF
--- a/src/api/v2/account_activities.rs
+++ b/src/api/v2/account_activities.rs
@@ -151,6 +151,9 @@ pub struct TradeActivity {
   /// The time at which the execution occurred.
   #[serde(rename = "transaction_time", deserialize_with = "system_time_from_str")]
   pub transaction_time: SystemTime,
+  /// Type of Trade "fill" or "partial_fill"
+  #[serde(rename = "type")]
+  pub type_: String,
   /// The traded symbol.
   #[serde(rename = "symbol")]
   pub symbol: String,

--- a/src/api/v2/order.rs
+++ b/src/api/v2/order.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2020 Daniel Mueller <deso@posteo.net>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::ops::Deref;
+use std::{fmt, ops::Deref};
 use std::ops::Not;
 use std::time::SystemTime;
 
@@ -40,6 +40,12 @@ impl Deref for Id {
   fn deref(&self) -> &Self::Target {
     &self.0
   }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+       write!(f, "{}", self.0.to_string()) 
+    }
 }
 
 
@@ -125,6 +131,31 @@ pub enum Status {
   Unknown,
 }
 
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Status::New => write!(f, "new"),
+            Status::Replaced => write!(f, "replaced"),
+            Status::PartiallyFilled => write!(f, "partially_filled"),
+            Status::Filled => write!(f, "filled"),
+            Status::DoneForDay => write!(f, "done_for_day"),
+            Status::Canceled => write!(f, "canceled"),
+            Status::Expired => write!(f, "expired"),
+            Status::Accepted => write!(f, "accepted"),
+            Status::PendingNew => write!(f, "pending_new"),
+            Status::AcceptedForBidding => write!(f, "accepted_for_bidding"),
+            Status::PendingCancel => write!(f, "pending_cancel"),
+            Status::PendingReplace => write!(f, "pending_replace"),
+            Status::Stopped => write!(f, "stopped"),
+            Status::Rejected => write!(f, "rejected"),
+            Status::Suspended => write!(f, "suspended"),
+            Status::Calculated => write!(f, "calculated"),
+            Status::Held => write!(f, "held"),
+            Status::Unknown => write!(f, "unknown")
+        }
+    }
+}
+
 
 /// The side an order is on.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
@@ -146,6 +177,15 @@ impl Not for Side {
       Self::Sell => Self::Buy,
     }
   }
+}
+
+impl fmt::Display for Side {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Buy => write!(f, "buy"),
+            Self::Sell => write!(f, "sell")
+        }
+    }
 }
 
 
@@ -180,6 +220,17 @@ impl Default for Class {
   }
 }
 
+impl fmt::Display for Class {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Simple => write!(f, "simple"),
+            Self::Bracket => write!(f, "bracket"),
+            Self::OneCancelsOther => write!(f, "oco"),
+            Self::OneTriggersOther => write!(f, "oto")
+        }
+    }
+}
+
 
 /// The type of an order.
 // Note that we currently do not support `stop_limit` orders.
@@ -205,6 +256,17 @@ impl Default for Type {
   }
 }
 
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Market => write!(f, "market"),
+            Self::Limit => write!(f, "limit"),
+            Self::Stop => write!(f, "stop"),
+            Self::StopLimit => write!(f, "stop_limit")
+        }
+    }
+}
+
 
 /// A description of the time for which an order is valid.
 #[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq)]
@@ -224,12 +286,37 @@ pub enum TimeInForce {
   /// auction. Any unfilled orders after the close will be canceled.
   #[serde(rename = "cls")]
   UntilMarketClose,
+  /// An Immediate Or Cancel (IOC) order requires all or part of the order to be executed
+  /// immediately. Any unfilled portion of the order is canceled. Only available with API v2. Most
+  /// market makers who receive IOC orders will attempt to fill the order on a principal basis
+  /// only, and cancel any unfilled balance. On occasion, this can result in the entire order being
+  /// cancelled if the market maker does not have any existing inventory of the security in
+  /// question.
+  #[serde(rename = "ioc")]
+  ImmediateOrCancel,
+  /// A Fill or Kill (FOK) order is only executed if the entire 
+  /// order quantity can be filled, otherwise the order is canceled.
+  #[serde(rename = "fok")]
+  FillOrKill
 }
 
 impl Default for TimeInForce {
   fn default() -> Self {
     Self::Day
   }
+}
+
+impl fmt::Display for TimeInForce {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Day => write!(f, "day"),
+            Self::UntilCanceled => write!(f, "gtc"),
+            Self::UntilMarketOpen => write!(f, "opg"),
+            Self::UntilMarketClose => write!(f, "cls"),
+            Self::ImmediateOrCancel => write!(f, "ioc"),
+            Self::FillOrKill => write!(f, "fok"),
+        }
+    }
 }
 
 

--- a/src/api/v2/order.rs
+++ b/src/api/v2/order.rs
@@ -248,6 +248,9 @@ pub enum Type {
   /// A stop limit order.
   #[serde(rename = "stop_limit")]
   StopLimit,
+  /// Trailing Stop
+  #[serde(rename = "trailing_stop")]
+  TrailingStop
 }
 
 impl Default for Type {
@@ -262,7 +265,8 @@ impl fmt::Display for Type {
             Self::Market => write!(f, "market"),
             Self::Limit => write!(f, "limit"),
             Self::Stop => write!(f, "stop"),
-            Self::StopLimit => write!(f, "stop_limit")
+            Self::StopLimit => write!(f, "stop_limit"),
+            Self::TrailingStop => write!(f, "trailing_stop")
         }
     }
 }
@@ -389,6 +393,10 @@ pub struct OrderReqInit {
   pub limit_price: Option<Num>,
   /// See `OrderReq::stop_price`.
   pub stop_price: Option<Num>,
+  /// See `OrderReq::trail_price`.
+  pub trail_price: Option<Num>,
+  /// See `OrderReq::trail_percent`.
+  pub trail_percent: Option<Num>,
   /// See `OrderReq::take_profit`.
   pub take_profit: Option<TakeProfit>,
   /// See `OrderReq::stop_loss`.
@@ -420,6 +428,8 @@ impl OrderReqInit {
       stop_loss: self.stop_loss,
       extended_hours: self.extended_hours,
       client_order_id: self.client_order_id,
+      trail_price: self.trail_price,
+      trail_percent: self.trail_percent
     }
   }
 }
@@ -452,6 +462,12 @@ pub struct OrderReq {
   /// The stop price.
   #[serde(rename = "stop_price")]
   pub stop_price: Option<Num>,
+  /// The trailing stop offset in dollars
+  #[serde(rename = "trail_price")]
+  pub trail_price: Option<Num>,
+  /// The trailing stop offset as a percent
+  #[serde(rename = "trail_percent")]
+  pub trail_percent: Option<Num>,
   /// Take profit information for bracket-style orders.
   #[serde(rename = "take_profit")]
   pub take_profit: Option<TakeProfit>,


### PR DESCRIPTION
The Alpaca API recently updated to support Fill Or Kill (fok) and Immediate Or Cancel (ioc) variants for TimeInForce.

I also added std::fmt::Display to most Order sub-types. (note: I used pattern matching, there may exist a trivial way to do this using Serde's renamed values.)