### PR TITLE
Migration of SystemTime to chrono::DateTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ A create for interacting with the Alpaca API.
 include = ["src/**/*", "LICENSE", "README.*", "CHANGELOG.*"]
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
 futures = {version = "0.3", default-features = false}
 http = {version = "0.2", default-features = false}
 http-endpoint = "0.5"

--- a/src/api/v2/account.rs
+++ b/src/api/v2/account.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::ops::Deref;
-use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
 
 use num_decimal::Num;
 
@@ -10,10 +11,7 @@ use serde::Deserialize;
 
 use uuid::Uuid;
 
-use time_util::system_time_from_str;
-
 use crate::Str;
-
 
 /// A type representing an account ID.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq)]
@@ -93,8 +91,8 @@ pub struct Account {
   #[serde(rename = "account_blocked")]
   pub account_blocked: bool,
   /// Timestamp this account was created at.
-  #[serde(rename = "created_at", deserialize_with = "system_time_from_str")]
-  pub created_at: SystemTime,
+  #[serde(rename = "created_at")]
+  pub created_at: DateTime<Utc>,
   /// Flag to denote whether or not the account is permitted to short.
   #[serde(rename = "shorting_enabled")]
   pub shorting_enabled: bool,
@@ -165,8 +163,6 @@ mod tests {
 
   use test_env_log::test;
 
-  use time_util::parse_system_time_from_str;
-
   use uuid::Uuid;
 
   use crate::api::API_BASE_URL;
@@ -211,7 +207,7 @@ mod tests {
     assert_eq!(acc.trading_blocked, false);
     assert_eq!(
       acc.created_at,
-      parse_system_time_from_str("2018-10-01T13:35:25Z").unwrap()
+      DateTime::parse_from_rfc3339("2018-10-01T13:35:25Z").unwrap()
     );
     assert_eq!(acc.market_value_long, Num::from(7000));
     assert_eq!(acc.market_value_short, Num::from(-3000));

--- a/src/api/v2/events.rs
+++ b/src/api/v2/events.rs
@@ -1,13 +1,11 @@
 // Copyright (C) 2019-2021 Daniel Mueller <deso@posteo.net>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::time::SystemTime;
+use chrono::{DateTime, Utc};
 
 use num_decimal::Num;
 
 use serde::Deserialize;
-
-use time_util::optional_system_time_from_str;
 
 use crate::api::v2::account;
 use crate::api::v2::order;
@@ -25,21 +23,18 @@ pub struct AccountUpdate {
   /// The time the account was created at.
   #[serde(
     rename = "created_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub created_at: Option<SystemTime>,
+  pub created_at: Option<DateTime<Utc>>,
   /// The time the account was updated last.
   #[serde(
     rename = "updated_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub updated_at: Option<SystemTime>,
+  pub updated_at: Option<DateTime<Utc>>,
   /// The time the account was deleted at.
   #[serde(
     rename = "deleted_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub deleted_at: Option<SystemTime>,
+  pub deleted_at: Option<DateTime<Utc>>,
   /// The account's status.
   #[serde(rename = "status")]
   pub status: String,

--- a/src/api/v2/order.rs
+++ b/src/api/v2/order.rs
@@ -3,7 +3,8 @@
 
 use std::ops::Deref;
 use std::ops::Not;
-use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
 
 use http::Method;
 use http_endpoint::Bytes;
@@ -20,9 +21,6 @@ use serde_json::to_vec as to_json;
 use serde_urlencoded::to_string as to_query;
 
 use uuid::Uuid;
-
-use time_util::optional_system_time_from_str;
-use time_util::system_time_from_str;
 
 use crate::api::v2::asset;
 use crate::api::v2::util::u64_from_str;
@@ -481,38 +479,33 @@ pub struct Order {
   #[serde(rename = "status")]
   pub status: Status,
   /// Timestamp this order was created at.
-  #[serde(rename = "created_at", deserialize_with = "system_time_from_str")]
-  pub created_at: SystemTime,
+  #[serde(rename = "created_at")]
+  pub created_at: DateTime<Utc>,
   /// Timestamp this order was updated at last.
   #[serde(
     rename = "updated_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub updated_at: Option<SystemTime>,
+  pub updated_at: Option<DateTime<Utc>>,
   /// Timestamp this order was submitted at.
   #[serde(
     rename = "submitted_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub submitted_at: Option<SystemTime>,
+  pub submitted_at: Option<DateTime<Utc>>,
   /// Timestamp this order was filled at.
   #[serde(
     rename = "filled_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub filled_at: Option<SystemTime>,
+  pub filled_at: Option<DateTime<Utc>>,
   /// Timestamp this order expired at.
   #[serde(
     rename = "expired_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub expired_at: Option<SystemTime>,
+  pub expired_at: Option<DateTime<Utc>>,
   /// Timestamp this order expired at.
   #[serde(
     rename = "canceled_at",
-    deserialize_with = "optional_system_time_from_str",
   )]
-  pub canceled_at: Option<SystemTime>,
+  pub canceled_at: Option<DateTime<Utc>>,
   /// The order's asset class.
   #[serde(rename = "asset_class")]
   pub asset_class: asset::Class,
@@ -734,8 +727,6 @@ mod tests {
 
   use serde_json::from_str as from_json;
 
-  use time_util::parse_system_time_from_str;
-
   use test_env_log::test;
 
   use uuid::Uuid;
@@ -816,7 +807,7 @@ mod tests {
     assert_eq!(order.id, id);
     assert_eq!(
       order.created_at,
-      parse_system_time_from_str("2018-10-05T05:48:59Z").unwrap()
+      DateTime::parse_from_rfc3339("2018-10-05T05:48:59Z").unwrap()
     );
     assert_eq!(order.symbol, "AAPL");
     assert_eq!(order.quantity, 15);

--- a/src/data/v1/bars.rs
+++ b/src/data/v1/bars.rs
@@ -4,13 +4,14 @@
 use std::collections::HashMap;
 use std::time::SystemTime;
 
+use chrono::{DateTime, Utc};
+
 use num_decimal::Num;
 
 use serde::Deserialize;
 use serde::Serialize;
 use serde_urlencoded::to_string as to_query;
 
-use time_util::optional_system_time_to_rfc3339;
 use time_util::system_time_from_secs;
 
 use crate::data::DATA_BASE_URL;
@@ -48,7 +49,7 @@ pub struct BarReqInit {
   /// See `BarReq::limit`.
   pub limit: usize,
   /// See `BarReq::end`.
-  pub end: Option<SystemTime>,
+  pub end: Option<DateTime<Utc>>,
   #[doc(hidden)]
   pub _non_exhaustive: (),
 }
@@ -89,8 +90,8 @@ pub struct BarReq {
   #[serde(rename = "limit")]
   pub limit: usize,
   /// Filter bars equal to or before this time.
-  #[serde(rename = "end", serialize_with = "optional_system_time_to_rfc3339")]
-  pub end: Option<SystemTime>,
+  #[serde(rename = "end")]
+  pub end: Option<DateTime<Utc>>,
 }
 
 
@@ -153,6 +154,8 @@ mod tests {
   use std::time::Duration;
   use std::time::UNIX_EPOCH;
 
+  use chrono::NaiveDateTime;
+
   use http_endpoint::Endpoint;
 
   use serde_json::from_str as from_json;
@@ -193,11 +196,10 @@ mod tests {
   async fn request_bars() {
     let api_info = ApiInfo::from_env().unwrap();
     let client = Client::new(api_info);
-    let end = UNIX_EPOCH + Duration::from_secs(1544132820);
     let request = BarReq {
       symbol: "AAPL".to_string(),
       limit: 2,
-      end: Some(end),
+      end: Some(chrono::DateTime::from_utc(NaiveDateTime::from_timestamp(1544132820, 0), Utc)),
     };
     let bars = client
       .issue::<Get>(&(TimeFrame::OneDay, request))


### PR DESCRIPTION
Closes #13.

Notes:
- `src/data/v1/bars.rs`: Bars response object actually uses a timestamp (in seconds) from UNIX epoch.
- `src/api/v2/account_activities.rs`: NonTradeActivity Entity seems to only send the date. I used `chrono::NaiveDate` here instead. There's an interface that abstracts over TradeActivity and NonTradeActivity. I updated this to use `chrono::DateTime<Utc>` and to convert the `chrono::NaiveDate` to a `DateTime<Utc>`, although that's probably not the best way to do things.

Questions:
- Is there a rustfmt config I can use to ensure my changes are formatted?
- How do I run the tests? All of the ones that attempt to connect to an Alpaca account fail because I don't have my environment set up. Can I just set it up with any paper trading account and expect the tests to work?