### PR TITLE
Allow filtering of GET /v2/orders by simple symbols.

### DIFF
--- a/src/api/v2/order_util.rs
+++ b/src/api/v2/order_util.rs
@@ -10,15 +10,22 @@ use crate::api::v2::order::Type;
 use crate::Client;
 use crate::RequestError;
 
-pub(crate) async fn order_aapl(
+pub(crate) async fn order_stock(
   client: &Client,
+  symbol: &str,
 ) -> Result<order::Order, RequestError<order::PostError>> {
   let request = order::OrderReqInit {
     type_: Type::Limit,
     limit_price: Some(Num::from(1)),
     ..Default::default()
   }
-  .init("AAPL", Side::Buy, Amount::quantity(1));
+  .init(symbol.to_string(), Side::Buy, Amount::quantity(1));
 
   client.issue::<order::Post>(&request).await
+}
+
+pub(crate) async fn order_aapl(
+  client: &Client,
+) -> Result<order::Order, RequestError<order::PostError>> {
+  order_stock(client, "AAPL").await
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -41,7 +41,7 @@ pub(crate) fn slice_to_str<S, F, T>(
 ) -> Result<S::Ok, S::Error>
 where
   S: Serializer,
-  F: Fn(&T) -> &'static str,
+  F: Fn(&T) -> String,
   T: Serialize,
 {
   if !slice.is_empty() {
@@ -67,14 +67,28 @@ where
   S: Serializer,
   T: Serialize,
 {
-  fn name_fn<T>(variant: &T) -> &'static str
+  fn name_fn<T>(variant: &T) -> String
   where
     T: Serialize,
   {
     // We know that we are dealing with an enum variant and the
     // function will never return an error for those, so it's fine
     // to unwrap.
-    to_variant_name(variant).unwrap()
+    to_variant_name(variant).unwrap().to_string()
+  }
+
+  slice_to_str(slice, name_fn, serializer)
+}
+
+/// Serialize a slice of strings into a comma-separated string combining the
+/// individual strings.
+pub(crate) fn string_slice_to_str<S>(slice: &[String], serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: Serializer,
+{
+  fn name_fn(string: &String) -> String
+  {
+    string.to_string()
   }
 
   slice_to_str(slice, name_fn, serializer)


### PR DESCRIPTION
Fixes #8.