### PR TITLE
Modify the client to use the `request` create instead of `hyper` for …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ http-endpoint = "0.5"
 hyper = {version = "0.14", features = ["client", "http1", "stream"]}
 hyper-tls = {version = "0.5", default-features = false}
 num-decimal = {version = "0.2.4", default-features = false, features = ["num-v04", "serde"]}
+reqwest = {version = "0.11.10"}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", default-features = false, features = ["std"]}
 serde_urlencoded = {version = "0.7", default-features = false}
@@ -49,3 +50,6 @@ tokio = {version = "1.0", default-features = false, features = ["rt-multi-thread
 tracing-subscriber = {version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt"]}
 uuid = {version = "1.0", default-features = false, features = ["v4"]}
 websocket-util = {version = "0.10.1", features = ["test"]}
+
+[features]
+gzip = ["reqwest/gzip"]

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -15,6 +15,9 @@ pub enum ConversionError {
   /// A variant used when we fail to URL-encode a piece of data.
   #[error("failed to URL-encode data")]
   UrlEncode(#[from] UrlEncodeError),
+  /// A variant used when a Reqwest fails to convert from an HttpRequest.
+  #[error("failed to URL-encode data")]
+  ReqwestError(#[from] reqwest::Error),
 }
 
 use thiserror::Error;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2019-2022 The apca Developers
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use reqwest;
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
@@ -9,7 +10,6 @@ use std::str::from_utf8;
 
 use http::Error as HttpError;
 use http::StatusCode as HttpStatusCode;
-use hyper::Error as HyperError;
 use serde_json::Error as JsonError;
 use thiserror::Error;
 use url::ParseError;
@@ -24,12 +24,12 @@ pub enum RequestError<E> {
   /// An endpoint reported error.
   #[error("the endpoint reported an error")]
   Endpoint(#[source] E),
-  /// An error reported by the `hyper` crate.
-  #[error("the hyper crate reported an error")]
-  Hyper(
+  /// An error reported by the `reqwest` crate.
+  #[error("the reqwest crate reported an error")]
+  Reqwest(
     #[from]
     #[source]
-    HyperError,
+    reqwest::Error,
   ),
 }
 


### PR DESCRIPTION
…HTTP traffic.

This allows the utlization of gzip response encoding via the [`gzip` feature flag](https://docs.rs/reqwest/0.11.10/reqwest/struct.ClientBuilder.html#method.gzip).

Unfortunately, `reqwest` silently decodes the response and [removes the encoding header](https://github.com/seanmonstar/reqwest/blob/master/src/async_impl/decoder.rs#L173) making it difficult (impossible?) to write a test verifying the behavior. However, I did use a local branch of the `reqwest` crate, with added debugging and printing, to confirm that the gzip decompression was happening.

Other than that, running `cargo test --features gzip` shows all tests passing.

Fixes #34