### PR TITLE
Add gzip support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async-compression = {version = "0.3.12", optional = true}
 async-trait = "0.1.51"
 chrono = {version = "0.4.19", features = ["serde"]}
 futures = {version = "0.3", default-features = false}
-futures-util = {version = "0.3.21", optional = true}
 http = {version = "0.2", default-features = false}
 http-endpoint = "0.5"
 hyper = {version = "0.14", features = ["client", "http1", "stream"]}
@@ -54,4 +53,4 @@ uuid = {version = "1.0", default-features = false, features = ["v4"]}
 websocket-util = {version = "0.10.1", features = ["test"]}
 
 [features]
-gzip = ["async-compression/gzip", "async-compression/tokio", "tokio/io-util", "dep:futures-util", "dep:tokio-util"]
+gzip = ["async-compression/gzip", "async-compression/futures-io"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ A crate for interacting with the Alpaca API.
 include = ["src/**/*", "LICENSE", "README.*", "CHANGELOG.*"]
 
 [dependencies]
+async-compression = {version = "0.3.12", optional = true}
 async-trait = "0.1.51"
 chrono = {version = "0.4.19", features = ["serde"]}
 futures = {version = "0.3", default-features = false}
+futures-util = {version = "0.3.21", optional = true}
 http = {version = "0.2", default-features = false}
 http-endpoint = "0.5"
 hyper = {version = "0.14", features = ["client", "http1", "stream"]}
@@ -35,6 +37,7 @@ serde_urlencoded = {version = "0.7", default-features = false}
 serde_variant = {version = "0.1", default-features = false}
 thiserror = "1.0.30"
 tokio = {version = "1.0", default-features = false, features = ["net"]}
+tokio-util = {version = "0.7.1", optional = true, features = ["compat"]}
 tracing = {version = "0.1", default-features = false, features = ["attributes", "std"]}
 tracing-futures = {version = "0.2", default-features = false, features = ["std-future"]}
 tungstenite = {package = "tokio-tungstenite", version = "0.16", features = ["connect", "native-tls"]}
@@ -49,3 +52,6 @@ tokio = {version = "1.0", default-features = false, features = ["rt-multi-thread
 tracing-subscriber = {version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt"]}
 uuid = {version = "1.0", default-features = false, features = ["v4"]}
 websocket-util = {version = "0.10.1", features = ["test"]}
+
+[features]
+gzip = ["async-compression/gzip", "async-compression/tokio", "tokio/io-util", "dep:futures-util", "dep:tokio-util"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Result as FmtResult;
+use std::io::Error as IoError;
 use std::str::from_utf8;
 
 use http::Error as HttpError;
@@ -30,6 +31,13 @@ pub enum RequestError<E> {
     #[from]
     #[source]
     HyperError,
+  ),
+  /// An error reported by the `hyper` crate.
+  #[error("could not convert hyper body to AsyncRead")]
+  AsyncReadConversion(
+    #[from]
+    #[source]
+    IoError,
   ),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,3 @@ pub use crate::error::RequestError;
 pub use crate::subscribable::Subscribable;
 
 type Str = Cow<'static, str>;
-
-/// A response header key defining the response encoding.
-pub(crate) const CONTENT_ENCODING_KEY: &str = "Content-Encoding";
-/// A Content-Encoding value denoting gzip encoding.
-#[cfg(feature = "gzip")]
-pub(crate) const GZIP_ENCODING: &str = "gzip";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,9 @@ pub use crate::error::RequestError;
 pub use crate::subscribable::Subscribable;
 
 type Str = Cow<'static, str>;
+
+/// A response header key defining the response encoding.
+pub(crate) const CONTENT_ENCODING_KEY: &str = "Content-Encoding";
+/// A Content-Encoding value denoting gzip encoding.
+#[cfg(feature = "gzip")]
+pub(crate) const GZIP_ENCODING: &str = "gzip";


### PR DESCRIPTION
Add a gzip feature. When this feature is enabled, requests include an "Accept-Encoding": "gzip" header. If the response also contains a "Content-Encoding": "gzip" header, then the body is gzip decoded before being processed.
