### PR TITLE
Added support for streaming real-time trade data

### DIFF
--- a/examples/stream-realtime-data.rs
+++ b/examples/stream-realtime-data.rs
@@ -32,6 +32,8 @@ async fn main() {
   data.set_bars(["SPY", "XLK"]);
   // ... and realtime quotes for AAPL.
   data.set_quotes(["AAPL"]);
+  // ... and realtime trades for MSFT.
+  data.set_trades(["MSFT"]);
 
   let subscribe = subscription.subscribe(&data).boxed();
   // Actually subscribe with the websocket server.

--- a/src/data/v2/stream.rs
+++ b/src/data/v2/stream.rs
@@ -1216,7 +1216,7 @@ mod tests {
     }
   }
 
-  /// Check that we can stream realtime stock quotes.
+  /// Check that we can stream realtime stock trades.
   ///
   /// the equivalent to the `stream_quotes` test but with trades
   #[test(tokio::test)]


### PR DESCRIPTION
Additionally to quotes and bars, alpaca also provides trade data. I have added another struct to `streams.rs` to handle this data, two tests, and modified the `stream-realtime-data.rs` example to also provide trade data.

I kept the coding style as close to the existing code as possible, however it seems that my linter removed some blank lines from `stream.rs`.