### PR TITLE
Latest trade data

### DIFF
--- a/examples/latest-quote-and-trade.rs
+++ b/examples/latest-quote-and-trade.rs
@@ -1,0 +1,41 @@
+// Copyright (C) 2020-2022 The apca Developers
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use apca::data::v2::{last_quote, last_trade};
+use apca::ApiInfo;
+use apca::Client;
+
+#[tokio::main]
+async fn main() {
+  // Requires the following environment variables to be present:
+  // - APCA_API_KEY_ID -> your API key
+  // - APCA_API_SECRET_KEY -> your secret key
+  //
+  // Optionally, the following variable is honored:
+  // - APCA_API_BASE_URL -> the API base URL to use (set to
+  //   https://api.alpaca.markets for live trading)
+  let api_info = ApiInfo::from_env().unwrap();
+  let client = Client::new(api_info);
+
+  let quote_req = last_quote::LastQuoteReq::new(vec!["AAPL".to_string(), "MSFT".to_string()]);
+  let quotes = client.issue::<last_quote::Get>(&quote_req).await.unwrap();
+  quotes.iter().for_each(|q| {
+    println!(
+      "Latest quote for {}: Ask {}/{} Bid {}/{}",
+      q.symbol, q.ask_price, q.ask_size, q.bid_price, q.bid_size
+    )
+  });
+
+  let trade_req = last_trade::LastTradeRequest::new(vec![
+    "SPY".to_string(),
+    "QQQ".to_string(),
+    "IWM".to_string(),
+  ]);
+  let trades = client.issue::<last_trade::Get>(&trade_req).await.unwrap();
+  trades.iter().for_each(|trade| {
+    println!(
+      "Latest trade for {}: {} @ {}",
+      trade.symbol, trade.size, trade.price
+    );
+  });
+}

--- a/src/data/v2/mod.rs
+++ b/src/data/v2/mod.rs
@@ -8,6 +8,8 @@ mod unfold;
 pub mod bars;
 /// Functionality for retrieval of the most recent quote.
 pub mod last_quote;
+/// Functionality for retrieval of the most recent trade(s).
+pub mod last_trade;
 /// Functionality for retrieving historic quotes.
 pub mod quotes;
 /// Definitions for real-time streaming of market data.


### PR DESCRIPTION
This uses the [Latest Multi Trades endpoint](https://alpaca.markets/docs/api-references/market-data-api/stock-pricing-data/historical/#latest-multi-trades) to get the latest trade data for one or more symbols at once. This was heavily copied from the last_quote mod, but changed to deal with the JSON response as nested objects. I elected to return a vec of Trades with the symbol attached because it suits my needs. closes #42 