### PR TITLE
add quantity available field for position response

### DIFF
--- a/src/api/v2/position.rs
+++ b/src/api/v2/position.rs
@@ -15,7 +15,6 @@ use crate::api::v2::order;
 use crate::util::abs_num_from_str;
 use crate::Str;
 
-
 /// The side of a position.
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum Side {
@@ -39,7 +38,6 @@ impl Not for Side {
   }
 }
 
-
 /// A single position as returned by the /v2/positions endpoint on a GET
 /// request.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -62,6 +60,9 @@ pub struct Position {
   /// The number of shares.
   #[serde(rename = "qty", deserialize_with = "abs_num_from_str")]
   pub quantity: Num,
+  /// Total number of shares available minus open orders
+  #[serde(rename = "qty_available")]
+  pub quantity_available: Num,
   /// The side the position is on.
   #[serde(rename = "side")]
   pub side: Side,
@@ -94,7 +95,6 @@ pub struct Position {
   pub change_today: Option<Num>,
 }
 
-
 Endpoint! {
   /// The representation of a GET request to the /v2/positions/<symbol>
   /// endpoint.
@@ -113,7 +113,6 @@ Endpoint! {
     format!("/v2/positions/{}", input).into()
   }
 }
-
 
 Endpoint! {
   /// The representation of a DELETE request to the
@@ -139,7 +138,6 @@ Endpoint! {
   }
 }
 
-
 #[cfg(test)]
 mod tests {
   use super::*;
@@ -152,7 +150,6 @@ mod tests {
   use crate::api_info::ApiInfo;
   use crate::Client;
   use crate::RequestError;
-
 
   /// Check that we can negate a `Side` object.
   #[test]

--- a/src/api/v2/position.rs
+++ b/src/api/v2/position.rs
@@ -169,6 +169,7 @@ mod tests {
     "asset_class": "us_equity",
     "avg_entry_price": "100.0",
     "qty": "5",
+    "qty_available": "3",
     "side": "long",
     "market_value": "600.0",
     "cost_basis": "500.0",
@@ -188,6 +189,7 @@ mod tests {
     assert_eq!(pos.asset_class, asset::Class::UsEquity);
     assert_eq!(pos.average_entry_price, Num::from(100));
     assert_eq!(pos.quantity, Num::from(5));
+    assert_eq!(pos.quantity_available, Num::from(3));
     assert_eq!(pos.side, Side::Long);
     assert_eq!(pos.market_value, Some(Num::from(600)));
     assert_eq!(pos.cost_basis, Num::from(500));
@@ -210,6 +212,7 @@ mod tests {
     "asset_class": "us_equity",
     "avg_entry_price": "100.0",
     "qty": "0.5",
+    "qty_available": "0.5",
     "side": "long",
     "market_value": "600.0",
     "cost_basis": "500.0",
@@ -228,6 +231,7 @@ mod tests {
     assert_eq!(pos.asset_class, asset::Class::UsEquity);
     assert_eq!(pos.average_entry_price, Num::from(100));
     assert_eq!(pos.quantity, Num::new(1, 2));
+    assert_eq!(pos.quantity_available, Num::new(1, 2));
     assert_eq!(pos.side, Side::Long);
     assert_eq!(pos.market_value, Some(Num::from(600)));
     assert_eq!(pos.cost_basis, Num::from(500));
@@ -249,6 +253,7 @@ mod tests {
       "exchange":"ARCA",
       "asset_class":"us_equity",
       "qty":"-24",
+      "qty_available": "-24",
       "avg_entry_price":"82.69",
       "side":"short",
       "market_value":"-2011.44",
@@ -265,6 +270,7 @@ mod tests {
     let pos = from_json::<Position>(response).unwrap();
     assert_eq!(pos.symbol, "XLK");
     assert_eq!(pos.quantity, Num::from(24));
+    assert_eq!(pos.quantity_available, Num::from(-24));
   }
 
   /// Check that we can retrieve an open position, if one exists.


### PR DESCRIPTION
Position response is missing `qty_available` property from the response. This property is helpful in making decisions about selling shares. 

https://alpaca.markets/docs/api-references/trading-api/positions/

Property added to Position struct: `qty_available`