### PR TITLE
Added optional rustls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ A crate for interacting with the Alpaca API.
 include = ["src/**/*", "LICENSE", "README.*", "CHANGELOG.*"]
 
 [features]
-default = ["gzip"]
+default = ["gzip", "native-tls"]
 gzip = ["async-compression/futures-io", "async-compression/gzip"]
-vendored-openssl = ["hyper-tls/vendored"]
+vendored-openssl = ["hyper-tls?/vendored", "dep:hyper-tls"]
+native-tls = ["tungstenite/native-tls", "dep:hyper-tls"]
+rustls = ["hyper/tcp", "dep:hyper-rustls", "websocket-util/rustls", "tungstenite/__rustls-tls"]
 
 [dependencies]
 async-compression = {version = "0.3.12", default-features = false, optional = true}
@@ -34,8 +36,9 @@ futures = {version = "0.3", default-features = false}
 http = {version = "0.2", default-features = false}
 http-endpoint = "0.5"
 hyper = {version = "0.14", features = ["client", "http1", "stream"]}
-hyper-tls = {version = "0.5", default-features = false}
+hyper-tls = {version = "0.5", default-features = false, optional = true}
 num-decimal = {version = "0.2.4", default-features = false, features = ["num-v04", "serde"]}
+hyper-rustls = {version = "0.24", optional = true}
 serde = {version = "1.0.103", features = ["derive"]}
 serde_json = {version = "1.0", default-features = false, features = ["std"]}
 serde_urlencoded = {version = "0.7", default-features = false}
@@ -44,7 +47,7 @@ thiserror = "1.0.30"
 tokio = {version = "1.0", default-features = false, features = ["net"]}
 tracing = {version = "0.1", default-features = false, features = ["attributes", "std"]}
 tracing-futures = {version = "0.2", default-features = false, features = ["std-future"]}
-tungstenite = {package = "tokio-tungstenite", version = "0.18", features = ["connect", "native-tls"]}
+tungstenite = {package = "tokio-tungstenite", version = "0.19", features = ["connect"]}
 url = "2.0"
 uuid = {version = "1.0", default-features = false, features = ["serde"]}
 websocket-util = "0.11.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -22,7 +22,12 @@ use hyper::client::HttpConnector;
 use hyper::Body;
 use hyper::Client as HttpClient;
 use hyper::Error as HyperError;
+
+#[cfg(feature = "native-tls")]
 use hyper_tls::HttpsConnector;
+
+#[cfg(feature = "rustls")]
+use hyper_rustls::{HttpsConnector, HttpsConnectorBuilder};
 
 use tracing::debug;
 use tracing::field::debug;
@@ -113,7 +118,16 @@ impl Builder {
 
   /// Build the final `Client` object.
   pub fn build(&self, api_info: ApiInfo) -> Client {
+    #[cfg(feature = "native-tls")]
     let https = HttpsConnector::new();
+
+    #[cfg(feature = "rustls")]
+    let https = HttpsConnectorBuilder::new()
+      .with_native_roots()
+      .https_only()
+      .enable_http1()
+      .build();
+
     let client = self.builder.build(https);
 
     Client { api_info, client }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,10 @@
 
 //! A crate for interacting with the Alpaca API.
 
+// Do not allow `rustls` and `native-tls` to be used at the same time.
+#[cfg(all(feature = "rustls", feature = "native-tls"))]
+compile_error!("features `rustls` and `native-tls` are mutually exclusive");
+
 #[macro_use]
 extern crate http_endpoint;
 


### PR DESCRIPTION
This pull request solves the following issue:

#57 

It adds an optional flag to use `rustls` instead of `hypertls` for SSL communication.