### PR TITLE
Exposing apca's version of num_decimal

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,4 +115,6 @@ pub use crate::error::Error;
 pub use crate::error::RequestError;
 pub use crate::subscribable::Subscribable;
 
+pub use num_decimal;
+
 type Str = Cow<'static, str>;


### PR DESCRIPTION
I ran into this issue while making an application so I figured I'd just make this PR. When using apca it's been a pain trying to use the num_decimal crate along with it. I figured that just exporting it in apca would help because someone using this crate doesn't have to dig through the code to get the specific version number for compatibility.